### PR TITLE
[TVPv7][BUGFIX] if new content is created in LIST module it is not linked

### DIFF
--- a/Classes/Service/DataHandling/DataHandler.php
+++ b/Classes/Service/DataHandling/DataHandler.php
@@ -257,6 +257,7 @@ page.10.disableExplosivePreview = 1';
                                     $destinationFlexformPointer['position'] = array_search($reference->substNEWwithIDs[$id], array_keys($sort));
                                 }
                             }
+                            $templaVoilaAPI->insertElement_setElementReferences($destinationFlexformPointer, $reference->substNEWwithIDs[$id]);
                         }
                     } else {
                         $templaVoilaAPI->insertElement_setElementReferences($destinationFlexformPointer, $reference->substNEWwithIDs[$id]);


### PR DESCRIPTION
If content is created in LIST module there was an algorithm
that tried to detect the correct CE-field in the TV+ datastructure.
However this does not work anymore and should be fixed.