### PR TITLE
[TVPv8] [FEATURE] CSS: page module and CE-wizard should use basic TYPO3 styles

### DIFF
--- a/Classes/Controller/Backend/Ajax/ContentElementWizard.php
+++ b/Classes/Controller/Backend/Ajax/ContentElementWizard.php
@@ -41,7 +41,11 @@ class ContentElementWizard extends AbstractResponse
         $contentElementsConfig = $this->modifyContentElementsConfig($contentElementsConfig);
         $contentElementsConfig = $this->convertParamsValue($contentElementsConfig);
 
-        $view = $this->getFluidTemplateObject('EXT:templavoilaplus/Resources/Private/Templates/Backend/Ajax/ContentElements.html');
+        if (version_compare(TYPO3_version, '11.2.0', '>=')) {
+            $view = $this->getFluidTemplateObject('EXT:templavoilaplus/Resources/Private/Templates/Backend/Ajax/ContentElements.html');
+        } else {
+            $view = $this->getFluidTemplateObject('EXT:templavoilaplus/Resources/Private/Templates/Backend/Ajax/ContentElements10LTS.html');
+        }
         $view->assign('contentElementsConfig', $contentElementsConfig);
 
         return new HtmlResponse($view->render());

--- a/Resources/Private/Templates/Backend/Ajax/ContentElements10LTS.html
+++ b/Resources/Private/Templates/Backend/Ajax/ContentElements10LTS.html
@@ -1,0 +1,38 @@
+{namespace core = TYPO3\CMS\Core\ViewHelpers}
+<div role="tabpanel" class="t3-new-content-element-wizard-window">
+  <ul class="nav nav-tabs t3js-tabs" role="tablist" id="tabs-DTM-tvpage" data-store-last-tab="1">
+    <f:for each="{contentElementsConfig}" as="section" key="sectionKey">
+      <li role="presentation" class="t3js-tabmenu-item">
+        <a class="nav-link" id="nav-{sectionKey}-tab" data-toggle="tab" href="#nav-{sectionKey}" role="tab" aria-controls="nav-{sectionKey}" aria-selected="false">{section.label}</a>
+      </li>
+    </f:for>
+  </ul>
+  <div class="tab-content" id="nav-tabContent">
+    <f:for each="{contentElementsConfig}" as="section" key="sectionKey">
+      <div class="tab-pane {f:if(condition: '{sectionKey} == \'common\'', then:'active')}" id="nav-{sectionKey}" role="tabpanel" aria-labelledby="nav-{sectionKey}-tab">
+        <div class="panel panel-tab">
+          <div class="panel-body">
+            <f:for each="{section.contentElements}" as="contentElement" key="contentElementKey">
+              <div class="row media media-new-content-element-wizard tvjs-drag" data-elementRow="{contentElement.element-row -> f:format.json()}">
+                <div class="col-1 media-left dragHandle">
+                  <core:icon identifier="{contentElement.iconIdentifier}" size="default"/>
+                </div>
+                <div class="col-11 media-body">
+                  <div><b>{contentElement.title}</b></div>
+                  <div>{contentElement.description}</div>
+                </div>
+              </div>
+            </f:for>
+          </div>
+        </div>
+      </div>
+    </f:for>
+  </div>
+</div>
+
+<script>
+    $('#nav-tab a').on('click', function (e) {
+        e.preventDefault()
+        $(this).tab('show')
+    })
+</script>

--- a/Resources/Public/StyleSheet/PageLayout.css
+++ b/Resources/Public/StyleSheet/PageLayout.css
@@ -390,6 +390,7 @@ div.warning a {
 /** Fix issue with trackingTooltip option, it can't see resizing as it gets a max-size */
 .tooltipster-sidetip .tooltipster-content {
     max-height: none;
+    width: 800px;
 }
 
 .tooltipster-sidetip .tooltipster-box {

--- a/Resources/Public/StyleSheet/PageLayout.css
+++ b/Resources/Public/StyleSheet/PageLayout.css
@@ -277,7 +277,7 @@ div.warning a {
 }
 
 #moduleWrapper {
-    height: calc(100% - 65px);
+    height: 100%;
 }
 
 .tvp-component-sidebar {

--- a/Resources/Public/StyleSheet/PageLayout.css
+++ b/Resources/Public/StyleSheet/PageLayout.css
@@ -337,6 +337,7 @@ div.warning a {
     margin: 0;
     list-style-type: none;
     height: 100%;
+    margin-top: 65px;
 }
 
 .sidenav-item {

--- a/Resources/Public/StyleSheet/PageLayout.css
+++ b/Resources/Public/StyleSheet/PageLayout.css
@@ -261,7 +261,6 @@ div.warning a {
 
 .module-body {
     height: 100%;
-    position: absolute;
     width: 100%;
     top: 65px;
 }


### PR DESCRIPTION
The top margin of the page module shows a lot of unnecessary whitespace on long pages; 
The CE wizard has some design problems with custom elements
Both could be circumvented using less overrides and more core-similar code