### PR TITLE
Fix failing tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,6 +127,7 @@
 		"ci:php:sniff:failOnErrors": "phpcs -n Classes Configuration Tests",
 		"ci:php:sniff:failOnWarnings": "phpcs Classes Configuration Tests",
 		"ci:php:stan": "phpstan --no-progress analyse --level 0",
+		"ci:php:stan:generateBaseline": "phpstan --no-progress analyse --level 0 --generate-baseline",
 		"ci:static": [
 			"@ci:composer:normalize",
 			"@ci:json:lint",


### PR DESCRIPTION
The current `main` refactored a few files, this PR accommodates oh-stan config for that.

Additionally a composer script  `composer run ci:php:stan:generateBaseline` is added to ease such future changes